### PR TITLE
optionals at end is more scala-friendly

### DIFF
--- a/modules/scraml-generator/src/main/scala/io/atomicbits/scraml/generator/CaseClassGenerator.scala
+++ b/modules/scraml-generator/src/main/scala/io/atomicbits/scraml/generator/CaseClassGenerator.scala
@@ -76,7 +76,7 @@ object CaseClassGenerator {
 
     val imports: Set[String] = collectImports()
 
-    val fieldExpressions = classRep.fields.map(_.fieldExpression)
+    val fieldExpressions = classRep.fields.sortBy(! _.required).map(_.fieldExpression)
 
     val caseClassSource =
       s"""


### PR DESCRIPTION
optional fields in case classes are moved to the end of the arguments list