### PR TITLE
updated test resources to force failure case

### DIFF
--- a/modules/scraml-raml-parser/src/test/resources/raml08/TestApi.raml
+++ b/modules/scraml-raml-parser/src/test/resources/raml08/TestApi.raml
@@ -49,6 +49,7 @@ traits:
         body:
           application/json:
             type: Book[]
+            example: !include examples/books.json
 
 /rest/user:
   !include user.raml

--- a/modules/scraml-raml-parser/src/test/resources/raml08/examples/books.json
+++ b/modules/scraml-raml-parser/src/test/resources/raml08/examples/books.json
@@ -1,0 +1,20 @@
+[
+  {
+    "isbn": "9780735300620",
+    "title": "Where the Wild Things Are",
+    "genre": "Fantasy Fiction",
+    "author": {
+      "firstName": "Maurice",
+      "lastName": "Sendak"
+    }
+  },
+  {
+    "isbn": "0079808800167",
+    "title": "Green Eggs and Ham",
+    "genre": "Children's literature",
+    "author": {
+      "firstName": "Dr.",
+      "lastName": "Seuss"
+    }
+  }
+]


### PR DESCRIPTION
## Context:
When the RAML source contains JSON includes consisting of a top level list, `io.atomicbits.scraml.ramlparser.parser.RamlToJsonParser` fails. The `parseToJson` method does not account for this case and is attempting to make an invalid cast on the parsed contents. This PR contains an update to the test resources to demonstrate this issue. I'll open a separate PR shortly with a proposed fix.
## Related:
[fix](https://github.com/atomicbits/scraml/pull/143)