### PR TITLE
Fix/json list includes

### DIFF
--- a/modules/scraml-raml-parser/src/main/scala/io/atomicbits/scraml/ramlparser/parser/RamltoJsonParser.scala
+++ b/modules/scraml-raml-parser/src/main/scala/io/atomicbits/scraml/ramlparser/parser/RamltoJsonParser.scala
@@ -42,10 +42,8 @@ object RamlToJsonParser {
       val SourceFile(path, ramlContent) = SourceReader.read(source, charsetName)
       val ramlContentNoTabs             = ramlContent.replace("\t", "  ") // apparently, the yaml parser does not handle tabs well
       val yaml                          = new Yaml(SimpleRamlConstructor())
-      val ramlMap: Any = {
-        val yamled = yaml.load(ramlContentNoTabs)
-        Try(yamled.asInstanceOf[java.util.Map[Any, Any]]).getOrElse(yamled.asInstanceOf[String])
-      }
+      val ramlMap: Any = (yaml load ramlContentNoTabs)
+
       (path, anyToJson(ramlMap))
     } match {
       case Success((path, jsvalue)) => JsonFile(path, jsvalue)

--- a/modules/scraml-raml-parser/src/test/resources/raml08/TestApi.raml
+++ b/modules/scraml-raml-parser/src/test/resources/raml08/TestApi.raml
@@ -49,6 +49,7 @@ traits:
         body:
           application/json:
             type: Book[]
+            example: !include examples/books.json
 
 /rest/user:
   !include user.raml

--- a/modules/scraml-raml-parser/src/test/resources/raml08/examples/books.json
+++ b/modules/scraml-raml-parser/src/test/resources/raml08/examples/books.json
@@ -1,0 +1,20 @@
+[
+  {
+    "isbn": "9780735300620",
+    "title": "Where the Wild Things Are",
+    "genre": "Fantasy Fiction",
+    "author": {
+      "firstName": "Maurice",
+      "lastName": "Sendak"
+    }
+  },
+  {
+    "isbn": "0079808800167",
+    "title": "Green Eggs and Ham",
+    "genre": "Children's literature",
+    "author": {
+      "firstName": "Dr.",
+      "lastName": "Seuss"
+    }
+  }
+]


### PR DESCRIPTION
## Context:
A fix the issue described [here](https://github.com/atomicbits/scraml/pull/142). The [problematic cast](https://github.com/atomicbits/scraml/compare/develop...ian-speers:fix/JSON-list-includes?expand=1#diff-97391f56e6e211b215a65bc6eae9e315L47) appears to be redundant, as this code path necessarily passes the result to `anyToJson` — which will handle the uncast laoded content. My solution was to simply remove it. If i've mis-assessed the issue please let me know. I'll be happy to revisit. 